### PR TITLE
fix: handle Angular routing in nginx to prevent 404 on refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 - Simplify generation of file with app version.
 
+### Fixed
+
+- Handle Angular routing in nginx to prevent 404 on refresh.
+
 
 
 ## [1.0.0] – 2024-11-22

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,11 +33,12 @@ RUN npm install
 # Build the Angular app.
 RUN npm run build
 
-
 # 2. Create final image from official nginx image.
 FROM nginx:${NGINX_IMAGE_TAG} AS final
 # Copy the dist/browser folder from the build image to the final, runtime image.
 COPY --from=build /digital-edition-cms-vincent/dist/vincent-cms/browser /usr/share/nginx/html
+# Copy custom nginx configuration file.
+COPY nginx.conf /etc/nginx/conf.d/default.conf
 # Expose port 80 to the outside world
 EXPOSE 80
 # Start nginx server

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,14 @@
+server {
+  listen 80;
+
+  server_name _;
+
+  root /usr/share/nginx/html;
+  index index.html;
+
+  location / {
+    try_files $uri /index.html;
+  }
+
+  error_page 404 /index.html;
+}


### PR DESCRIPTION
Added a custom nginx configuration to ensure all routes are redirected to index.html, allowing Angular's router to handle client-side routing. This resolves the 404 errors encountered when refreshing non-root routes.