### PR TITLE
fix: filter name and external URL fields on substring matches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+### Fixed
+
+- Filter name field in publications and publication collections, and external URL field in facsimile collections, on substring matches (opposed to exact matches).
+
 
 
 ## [1.0.1] – 2024-11-22

--- a/src/app/components/publications/columns.ts
+++ b/src/app/components/publications/columns.ts
@@ -2,7 +2,7 @@ import { Column } from "../../models/common";
 
 export const publicationColumnsData: Column[] = [
   { field: 'id', header: 'ID', type: 'id', editable: false, filterable: true },
-  { field: 'name', header: 'Name', type: 'string', editable: true, filterable: true, editOrder: 2 },
+  { field: 'name', header: 'Name', type: 'string', filterType: 'contains', editable: true, filterable: true, editOrder: 2 },
   { field: 'published', header: 'Published', type: 'published', editable: true, filterable: true, editOrder: 3 },
   { field: 'actions', header: 'Actions', type: 'action', editable: false },
 ];

--- a/src/app/pages/facsimiles/facsimiles.component.ts
+++ b/src/app/pages/facsimiles/facsimiles.component.ts
@@ -40,7 +40,7 @@ export class FacsimilesComponent implements OnInit {
     { field: 'description', header: 'Description', filterable: true, type: 'string', editable: true, filterType: 'contains' },
     { field: 'number_of_pages', header: 'Number of pages', filterable: false, type: 'number', editable: true },
     { field: 'start_page_number', header: 'Start page number', filterable: false, type: 'number', editable: true },
-    { field: 'external_url', header: 'External URL', filterable: true, type: 'string', editable: true },
+    { field: 'external_url', header: 'External URL', filterable: true, type: 'string', filterType: 'contains', editable: true },
     { field: 'actions', header: 'Actions', filterable: false, type: 'action' },
   ]
   allColumnData = [

--- a/src/app/pages/publication-collections/publication-collections.component.ts
+++ b/src/app/pages/publication-collections/publication-collections.component.ts
@@ -36,7 +36,7 @@ import { ConfirmDialogComponent } from '../../components/confirm-dialog/confirm-
 export class PublicationCollectionsComponent implements OnInit {
   publicationCollectionColumnsData: Column[] = [
     { field: 'id', header: 'ID', type: 'id', editable: false, filterable: true },
-    { field: 'name', header: 'Name', type: 'string', editable: true, filterable: true, translations: true, parentTranslationField: 'name_translation_id' },
+    { field: 'name', header: 'Name', type: 'string', filterType: 'contains', editable: true, filterable: true, translations: true, parentTranslationField: 'name_translation_id' },
     { field: 'published', header: 'Published', type: 'published', editable: true, filterable: true },
     { field: 'actions', header: 'Actions', type: 'action', editable: false },
   ];


### PR DESCRIPTION
Previously filtering on these fields would only return exact matches.