### PR TITLE
refactor: update terminology for 'published' field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 - Custom table component: move data subscription logic to ngOnInit.
 - Custom table component: move static filterable columns initialization outside data subscription logic.
 - Set default sorting of publication collections by name.
+- Set displayed values of the 'published' field to 'Production' and 'Review' instead of 'Externally' and 'Internally'. Add visual highlight to further distinguish the values in tables.
 - Deps (dev): update `angular-eslint` to 18.4.2.
 
 ### Fixed

--- a/src/app/components/custom-table/custom-table.component.html
+++ b/src/app/components/custom-table/custom-table.component.html
@@ -71,9 +71,9 @@
   } @else if (column.type === 'boolean') {
     {{ model[column.field] === 0 ? 'No' : 'Yes' }}
   } @else if (column.type === 'published') {
-    <ng-container *ngIf="model[column.field] === 0">Not published</ng-container>
-    <ng-container *ngIf="model[column.field] === 1">Internally</ng-container>
-    <ng-container *ngIf="model[column.field] === 2">Externally</ng-container>
+    <ng-container *ngIf="model[column.field] === 0"><span class="published-0">Not published</span></ng-container>
+    <ng-container *ngIf="model[column.field] === 1"><span class="published-1">Review</span></ng-container>
+    <ng-container *ngIf="model[column.field] === 2"><span class="published-2">Production</span></ng-container>
   } @else if (column.type === 'action') {
     <div class="row-actions">
       <button mat-icon-button (click)="edit(model)"><mat-icon>edit</mat-icon></button>

--- a/src/app/components/custom-table/custom-table.component.scss
+++ b/src/app/components/custom-table/custom-table.component.scss
@@ -49,6 +49,23 @@ td.mat-column-full_name {
   min-width: 250px;
 }
 
+td.mat-column-published {
+  span {
+    background-color: #eeeeee;
+    border-radius: 3px;
+    font-size: 0.8125rem;
+    padding: 0.125em 0.25em;
+
+    &.published-1 {
+      color: #7021BA;
+    }
+
+    &.published-2 {
+      color: #065e06;
+    }
+  }
+}
+
 .index {
   color: #9d9d9d;
 }

--- a/src/app/components/table-filters/table-filters.component.html
+++ b/src/app/components/table-filters/table-filters.component.html
@@ -9,8 +9,8 @@
             <mat-select [formControlName]="field.field">
               <mat-option>Any</mat-option>
               <mat-option [value]="0">Not published</mat-option>
-              <mat-option [value]="1">Internally</mat-option>
-              <mat-option [value]="2">Externally</mat-option>
+              <mat-option [value]="1">Review</mat-option>
+              <mat-option [value]="2">Production</mat-option>
             </mat-select>
           </ng-container>
           <ng-container *ngIf="field.type === 'boolean'">

--- a/src/app/models/common.ts
+++ b/src/app/models/common.ts
@@ -22,8 +22,8 @@ export enum Published {
 
 export const PublishedOptions = [
   { label: 'Not published', value: Published.NotPublished },
-  { label: 'Internally', value: Published.PublishedInternally },
-  { label: 'Externally', value: Published.PublishedExternally },
+  { label: 'Review', value: Published.PublishedInternally },
+  { label: 'Production', value: Published.PublishedExternally },
 ]
 
 export enum Deleted {


### PR DESCRIPTION
- Replaced 'Externally' with 'Production' and 'Internally' with 'Review' for clarity.
- Improved visual distinction and accessibility in the CMS.