### PR TITLE
fix(edit-dialog): allow getMetadata to update non-empty form fields w…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 ### Fixed
 
 - Typo in date created field name.
+- Edit dialog: allow getMetadata to update non-empty form fields with API data.
 
 
 

--- a/src/app/components/edit-dialog/edit-dialog.component.ts
+++ b/src/app/components/edit-dialog/edit-dialog.component.ts
@@ -180,7 +180,7 @@ export class EditDialogComponent<T> implements OnInit {
           if (Object.prototype.hasOwnProperty.call(metadata, key)) {
             const control = this.form.controls[key];
             const value = metadata[key as keyof XmlMetadata];
-            if (control && !!value && !this.form.value[key]) {
+            if (control && !!value) {
               control.setValue(value);
             }
           }


### PR DESCRIPTION
…ith API data

Previously, the getMetadata() method prevented form controls from being updated if they already had existing values, even when valid metadata was returned from the API. This change removes the restrictive condition, ensuring that form fields are properly updated with the metadata received.