### PR TITLE
fix: prevent repeated POST requests tied to `selectedProject$`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 ### Fixed
 
 - Clear the cached file tree when the project changes and the project git repository on the server is synced.
+- Prevent repeated POST requests tied to selected project, causing duplicate database writes for the same user action.
 
 
 

--- a/src/app/components/edit-dialog/edit-dialog.component.ts
+++ b/src/app/components/edit-dialog/edit-dialog.component.ts
@@ -181,7 +181,7 @@ export class EditDialogComponent<T> implements OnInit {
       finalize(() => {
         this.gettingMetadata = false;
       })
-    ).subscribe(metadata => {
+    ).subscribe((metadata: XmlMetadata) => {
       for (const key in metadata) {
         if (Object.prototype.hasOwnProperty.call(metadata, key)) {
           const control = this.form.controls[key];

--- a/src/app/components/facsimile-file/facsimile-file.component.ts
+++ b/src/app/components/facsimile-file/facsimile-file.component.ts
@@ -1,10 +1,11 @@
 import { AfterViewInit, Component, Input } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { HttpContext } from '@angular/common/http';
+import { BehaviorSubject, map } from 'rxjs';
+
+import { SkipLoading } from '../../interceptors/loading.interceptor';
 import { FacsimileService } from '../../services/facsimile.service';
 import { ApiService } from '../../services/api.service';
-import { BehaviorSubject, map } from 'rxjs';
-import { HttpContext } from '@angular/common/http';
-import { SkipLoading } from '../../interceptors/loading.interceptor';
 
 @Component({
   selector: 'facsimile-file',
@@ -45,6 +46,5 @@ export class FacsimileFileComponent implements AfterViewInit {
         next: url => this.imageUrlSubject.next(url),
       });
   }
-
 
 }

--- a/src/app/components/file-tree/file-tree.component.ts
+++ b/src/app/components/file-tree/file-tree.component.ts
@@ -1,12 +1,13 @@
 import { Component, EventEmitter, Input, OnDestroy, OnInit, Output } from '@angular/core';
+import { CommonModule } from '@angular/common';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
 import { MatTree, MatTreeModule } from '@angular/material/tree';
 import { filter, map, Subject, takeUntil } from 'rxjs';
-import { ProjectService } from '../../services/project.service';
+
 import { LoadingSpinnerComponent } from "../loading-spinner/loading-spinner.component";
-import { CommonModule } from '@angular/common';
 import { FileTree } from '../../models/project';
+import { ProjectService } from '../../services/project.service';
 
 interface TreeNode {
   name: string;

--- a/src/app/components/file-upload/file-upload.component.ts
+++ b/src/app/components/file-upload/file-upload.component.ts
@@ -97,7 +97,6 @@ export class FileUploadComponent {
         this.allUploaded = true;
         this.filesUploaded.emit();
         this.snackbar.open('All files uploaded', 'Close', { panelClass: 'snackbar-success' });
-
       },
     });
   }

--- a/src/app/components/navigation/navigation.component.ts
+++ b/src/app/components/navigation/navigation.component.ts
@@ -1,13 +1,14 @@
 import { CommonModule } from '@angular/common';
 import { Component, EventEmitter, OnDestroy, Output } from '@angular/core';
 import { MatDividerModule } from '@angular/material/divider';
-import { MatListModule } from '@angular/material/list';
-import { ProjectService } from '../../services/project.service';
-import { AuthService } from '../../services/auth.service';
 import { MatIconModule } from '@angular/material/icon';
+import { MatListModule } from '@angular/material/list';
 import { Router, RouterLink } from '@angular/router';
-import { navigationItems } from '../../models/common';
 import { Subject, takeUntil } from 'rxjs';
+
+import { navigationItems } from '../../models/common';
+import { AuthService } from '../../services/auth.service';
+import { ProjectService } from '../../services/project.service';
 
 @Component({
   selector: 'navigation',

--- a/src/app/components/publications/publications.component.ts
+++ b/src/app/components/publications/publications.component.ts
@@ -1,41 +1,51 @@
+import { BreakpointObserver } from '@angular/cdk/layout';
 import { CommonModule, DatePipe } from '@angular/common';
 import { Component, OnInit } from '@angular/core';
-import { BehaviorSubject, combineLatest, distinctUntilChanged, map, Observable, of, switchMap } from 'rxjs';
-import { Manuscript, Publication, PublicationComment, Version } from '../../models/publication';
-import { MatTableModule } from '@angular/material/table';
-import { CustomDatePipe } from '../../pipes/custom-date.pipe';
-import { MatIconModule } from '@angular/material/icon';
-import { MatButtonModule } from '@angular/material/button';
-import { MatMenuModule } from '@angular/material/menu';
-import { ActivatedRoute, RouterLink } from '@angular/router';
-import { LoadingSpinnerComponent } from '../loading-spinner/loading-spinner.component';
-import { MatDialog } from '@angular/material/dialog';
-import { MatCardModule } from '@angular/material/card';
-import { TableFiltersComponent } from '../table-filters/table-filters.component';
-import { TableSortingComponent } from '../table-sorting/table-sorting.component';
-import { QueryParamsService } from '../../services/query-params.service';
 import { MatBadgeModule } from '@angular/material/badge';
-import { EditDialogComponent, EditDialogData } from '../edit-dialog/edit-dialog.component';
+import { MatButtonModule } from '@angular/material/button';
+import { MatCardModule } from '@angular/material/card';
+import { MatDialog } from '@angular/material/dialog';
+import { MatIconModule } from '@angular/material/icon';
+import { MatMenuModule } from '@angular/material/menu';
 import { MatSnackBar } from '@angular/material/snack-bar';
-import { CustomTableComponent } from "../custom-table/custom-table.component";
-import { LoadingService } from '../../services/loading.service';
-import { PublicationFacsimile } from '../../models/facsimile';
-import { PublicationService } from '../../services/publication.service';
+import { MatTableModule } from '@angular/material/table';
+import { ActivatedRoute, RouterLink } from '@angular/router';
 import {
-  allCommentsColumnData, allFacsimileColumnData, allManuscriptColumnsData, allPublicationColumnsData, allVersionColumnsData,
-  commentsColumnData, facsimileColumnData, manuscriptColumnsData, publicationColumnsData, versionColumnsData
+  BehaviorSubject, combineLatest, distinctUntilChanged, map,
+  Observable, of, switchMap, take
+} from 'rxjs';
+
+import {
+  allCommentsColumnData, allFacsimileColumnData, allManuscriptColumnsData,
+  allPublicationColumnsData, allVersionColumnsData, commentsColumnData,
+  facsimileColumnData, manuscriptColumnsData, publicationColumnsData,
+  versionColumnsData
 } from './columns';
 import { ConfirmDialogComponent } from '../confirm-dialog/confirm-dialog.component';
-import { Column, Deleted } from '../../models/common';
-import { BreakpointObserver } from '@angular/cdk/layout';
+import { CustomTableComponent } from "../custom-table/custom-table.component";
+import { EditDialogComponent, EditDialogData } from '../edit-dialog/edit-dialog.component';
 import { FileTreeDialogComponent } from '../file-tree-dialog/file-tree-dialog.component';
+import { LoadingSpinnerComponent } from '../loading-spinner/loading-spinner.component';
+import { TableFiltersComponent } from '../table-filters/table-filters.component';
+import { TableSortingComponent } from '../table-sorting/table-sorting.component';
+import { LoadingService } from '../../services/loading.service';
+import { PublicationService } from '../../services/publication.service';
+import { QueryParamsService } from '../../services/query-params.service';
+import { CustomDatePipe } from '../../pipes/custom-date.pipe';
+import { Column, Deleted } from '../../models/common';
+import { LinkFacsimileToPublicationResponse, PublicationFacsimile } from '../../models/facsimile';
+import {
+  LinkTextToPublicationResponse, Manuscript, ManuscriptResponse, Publication,
+  PublicationComment, PublicationCommentResponse, PublicationResponse, Version,
+  VersionResponse
+} from '../../models/publication';
 import { cleanEmptyStrings, cleanObject } from '../../utils/utility-functions';
 
 @Component({
   selector: 'publications',
   imports: [
-    CommonModule, MatTableModule, CustomDatePipe, MatIconModule, MatButtonModule, RouterLink, LoadingSpinnerComponent,
-    MatCardModule, MatBadgeModule, MatMenuModule, CustomTableComponent
+    CommonModule, MatTableModule, CustomDatePipe, MatIconModule, MatButtonModule, RouterLink,
+    LoadingSpinnerComponent, MatCardModule, MatBadgeModule, MatMenuModule, CustomTableComponent
   ],
   providers: [DatePipe],
   templateUrl: './publications.component.html',
@@ -86,62 +96,52 @@ export class PublicationsComponent implements OnInit {
     this.isSmallScreen = this.breakpointObserver.isMatched('(max-width: 960px)');
     this.sortParams$ = this.queryParamsService.sortParams$;
     this.filterParams$ = this.queryParamsService.filterParams$;
-   }
+  }
 
   ngOnInit() {
-    this.publicationCollectionId$ = this.route.paramMap.pipe(map(params => params.get('collectionId')));
+    this.publicationCollectionId$ = this.route.paramMap.pipe(
+      map(params => params.get('collectionId'))
+    );
     this.publicationId$ = this.route.paramMap.pipe(map(params => params.get('publicationId')));
 
-
     this.publications$ = this.publicationsLoader$.asObservable().pipe(
-      switchMap(() => combineLatest([this.selectedProject$, this.publicationCollectionId$])
-        .pipe(
-          distinctUntilChanged(([, prevCollectionId], [, nextCollectionId]) => prevCollectionId === nextCollectionId),
-          switchMap(([, collectionId]) => this.publicationService.getPublications(collectionId as string))
-        )
-      ),
-    )
+      switchMap(() => combineLatest([this.selectedProject$, this.publicationCollectionId$]).pipe(
+        distinctUntilChanged(([, prevCollectionId], [, nextCollectionId]) => prevCollectionId === nextCollectionId),
+        switchMap(([, collectionId]) => this.publicationService.getPublications(collectionId as string))
+      ))
+    );
 
     this.selectedPublication$ = combineLatest([this.publications$, this.publicationId$]).pipe(
       map(([publications, publicationId]) => publications.find(publication => publication.id === parseInt(publicationId as string)) ?? null)
     );
 
     this.comments$ = this.commentLoader$.asObservable().pipe(
-      switchMap(() => combineLatest([this.publicationCollectionId$, this.publicationId$])
-        .pipe(
-          distinctUntilChanged(([, prevCollectionId], [, nextCollectionId]) => prevCollectionId === nextCollectionId),
-          switchMap(([collectionId, publicationId]) => this.publicationService.getCommentsForPublication(collectionId as string, publicationId as string))
-        )
-      )
+      switchMap(() => combineLatest([this.publicationCollectionId$, this.publicationId$]).pipe(
+        distinctUntilChanged(([, prevCollectionId], [, nextCollectionId]) => prevCollectionId === nextCollectionId),
+        switchMap(([collectionId, publicationId]) => this.publicationService.getCommentsForPublication(collectionId as string, publicationId as string))
+      ))
     );
 
     this.versions$ = this.versionsLoader$.asObservable().pipe(
-      switchMap(() => combineLatest([this.publicationCollectionId$, this.publicationId$])
-        .pipe(
-          distinctUntilChanged(([, prevCollectionId], [, nextCollectionId]) => prevCollectionId === nextCollectionId),
-          switchMap(([, publicationId]) => this.publicationService.getVersionsForPublication(publicationId as string))
-        )
-      )
+      switchMap(() => combineLatest([this.publicationCollectionId$, this.publicationId$]).pipe(
+        distinctUntilChanged(([, prevCollectionId], [, nextCollectionId]) => prevCollectionId === nextCollectionId),
+        switchMap(([, publicationId]) => this.publicationService.getVersionsForPublication(publicationId as string))
+      ))
     );
 
     this.manuscripts$ = this.manuscriptsLoader$.asObservable().pipe(
-      switchMap(() => combineLatest([this.publicationCollectionId$, this.publicationId$])
-        .pipe(
-          distinctUntilChanged(([, prevCollectionId], [, nextCollectionId]) => prevCollectionId === nextCollectionId),
-          switchMap(([, publicationId]) => this.publicationService.getManuscriptsForPublication(publicationId as string))
-        )
-      )
+      switchMap(() => combineLatest([this.publicationCollectionId$, this.publicationId$]).pipe(
+        distinctUntilChanged(([, prevCollectionId], [, nextCollectionId]) => prevCollectionId === nextCollectionId),
+        switchMap(([, publicationId]) => this.publicationService.getManuscriptsForPublication(publicationId as string))
+      ))
     );
 
     this.facsimiles$ = this.facsimilesLoader$.asObservable().pipe(
-      switchMap(() => combineLatest([this.publicationCollectionId$, this.publicationId$])
-        .pipe(
-          distinctUntilChanged(([, prevCollectionId], [, nextCollectionId]) => prevCollectionId === nextCollectionId),
-          switchMap(([, publicationId]) => this.publicationService.getFacsimilesForPublication(publicationId as string))
-        )
-      )
+      switchMap(() => combineLatest([this.publicationCollectionId$, this.publicationId$]).pipe(
+        distinctUntilChanged(([, prevCollectionId], [, nextCollectionId]) => prevCollectionId === nextCollectionId),
+        switchMap(([, publicationId]) => this.publicationService.getFacsimilesForPublication(publicationId as string))
+      ))
     );
-
   }
 
   editPublication(publication: Publication | null = null, collectionId: string) {
@@ -154,13 +154,13 @@ export class PublicationsComponent implements OnInit {
 
     dialogRef.afterClosed().subscribe(result => {
       if (result) {
-        let req;
+        let request$: Observable<PublicationResponse>;
         if (publication?.id) {
-          req = this.publicationService.editPublication(publication.id, result.form.value);
+          request$ = this.publicationService.editPublication(publication.id, result.form.value);
         } else {
-          req = this.publicationService.addPublication(parseInt(collectionId), result.form.value);
+          request$ = this.publicationService.addPublication(parseInt(collectionId), result.form.value);
         }
-        req.subscribe({
+        request$.pipe(take(1)).subscribe({
           next: () => {
             this.publicationsLoader$.next(0);
             if (result.form.value.cascade_published === true) {
@@ -187,10 +187,10 @@ export class PublicationsComponent implements OnInit {
       const filePath = result.join('/');
       const data = { original_filename: filePath };
 
-      this.publicationService.editPublication(publication.id, data).subscribe({
+      this.publicationService.editPublication(publication.id, data).pipe(take(1)).subscribe({
         next: () => {
           this.publicationsLoader$.next(0);
-          this.snackbar.open('Filename saved', 'Close', { panelClass: ['snackbar-success'] });
+          this.snackbar.open('File path saved', 'Close', { panelClass: ['snackbar-success'] });
         },
       });
     });
@@ -209,28 +209,24 @@ export class PublicationsComponent implements OnInit {
         let payload = result.form.getRawValue();
         payload['text_type'] = 'version';
 
-        const onSuccess = () => {
-          this.versionsLoader$.next(0);
-          this.snackbar.open('Variant saved', 'Close', {
-            panelClass: ['snackbar-success']
-          });
-        };
-
+        let request$: Observable<VersionResponse | LinkTextToPublicationResponse>;
         if (version?.id) {
           // Edit existing variant
           // Convert empty strings in field values to null in the payload object
           payload = cleanEmptyStrings(payload);
-          this.publicationService.editVersion(version.id, payload).subscribe({
-            next: onSuccess
-          });
+          request$ = this.publicationService.editVersion(version.id, payload);
         } else {
           // Add new variant
           // Remove empty fields from the payload object
           payload = cleanObject(payload);
-          this.publicationService.linkTextToPublication(publicationId, payload).subscribe({
-            next: onSuccess
-          });
+          request$ = this.publicationService.linkTextToPublication(publicationId, payload);
         }
+        request$.pipe(take(1)).subscribe({
+          next: () => {
+            this.versionsLoader$.next(0);
+            this.snackbar.open('Variant saved', 'Close', { panelClass: ['snackbar-success'] });
+          }
+        });
       }
     });
   }
@@ -248,28 +244,24 @@ export class PublicationsComponent implements OnInit {
         let payload = result.form.getRawValue();
         payload['text_type'] = 'manuscript';
 
-        const onSuccess = () => {
-          this.manuscriptsLoader$.next(0);
-          this.snackbar.open('Manuscript saved', 'Close', {
-            panelClass: ['snackbar-success']
-          });
-        };
-
+        let request$: Observable<ManuscriptResponse | LinkTextToPublicationResponse>;
         if (manuscript?.id) {
           // Edit existing manuscript
           // Convert empty strings in field values to null in the payload object
           payload = cleanEmptyStrings(payload);
-          this.publicationService.editManuscript(manuscript.id, payload).subscribe({
-            next: onSuccess
-          });
+          request$ = this.publicationService.editManuscript(manuscript.id, payload);
         } else {
           // Add new manuscript
           // Remove empty fields from the payload object
           payload = cleanObject(payload);
-          this.publicationService.linkTextToPublication(publicationId, payload).subscribe({
-            next: onSuccess
-          });
+          request$ = this.publicationService.linkTextToPublication(publicationId, payload);
         }
+        request$.pipe(take(1)).subscribe({
+          next: () => {
+            this.manuscriptsLoader$.next(0);
+            this.snackbar.open('Manuscript saved', 'Close', { panelClass: ['snackbar-success'] });
+          }
+        });
       }
     });
   }
@@ -282,32 +274,28 @@ export class PublicationsComponent implements OnInit {
     }
     const dialogRef = this.dialog.open(EditDialogComponent, { data });
 
-    const onSuccess = () => {
-      this.commentLoader$.next(0);
-      this.snackbar.open('Comment saved', 'Close', {
-        panelClass: ['snackbar-success']
-      });
-    };
-
     dialogRef.afterClosed().subscribe(result => {
       if (result) {
         let payload = result.form.getRawValue();
         payload['text_type'] = 'comment';
 
+        let request$: Observable<PublicationCommentResponse | LinkTextToPublicationResponse>;
         if (comment?.id) {
           // Edit existing comment
           // Convert empty strings in field values to null in the payload object
           payload = cleanEmptyStrings(payload);
-          this.publicationService.editComment(publicationId, payload).subscribe({
-            next: onSuccess
-          });
+          request$ = this.publicationService.editComment(publicationId, payload);
         } else {
           // Add new comment
           // Remove empty fields from the payload object
-          this.publicationService.linkTextToPublication(publicationId, payload).subscribe({
-            next: onSuccess
-          });
+          request$ = this.publicationService.linkTextToPublication(publicationId, payload);
         }
+        request$.pipe(take(1)).subscribe({
+          next: () => {
+            this.commentLoader$.next(0);
+            this.snackbar.open('Comment saved', 'Close', { panelClass: ['snackbar-success'] });
+          }
+        });
       }
     });
   }
@@ -325,26 +313,22 @@ export class PublicationsComponent implements OnInit {
     }
     const dialogRef = this.dialog.open(EditDialogComponent, { data });
 
-    const onSuccess = () => {
-      this.facsimilesLoader$.next(0);
-      this.snackbar.open('Facsimile saved', 'Close', {
-        panelClass: ['snackbar-success']
-      });
-    };
-
     dialogRef.afterClosed().subscribe(result => {
       if (result) {
         const payload = result.form.getRawValue();
 
+        let request$: Observable<LinkFacsimileToPublicationResponse>;
         if (facsimile?.id) {
-          this.publicationService.editFacsimileForPublication(payload).subscribe({
-            next: onSuccess
-          });
+          request$ = this.publicationService.editFacsimileForPublication(payload);
         } else {
-          this.publicationService.linkFacsimileToPublication(publicationId, result.form).subscribe({
-            next: onSuccess
-          });
+          request$ = this.publicationService.linkFacsimileToPublication(publicationId, result.form);
         }
+        request$.pipe(take(1)).subscribe({
+          next: () => {
+            this.facsimilesLoader$.next(0);
+            this.snackbar.open('Facsimile saved', 'Close', { panelClass: ['snackbar-success'] });
+          }
+        });
       }
     });
   }
@@ -361,7 +345,7 @@ export class PublicationsComponent implements OnInit {
     dialogRef.afterClosed().subscribe(result => {
       if (result?.value) {
         const payload = { id: facsimile.id, deleted: Deleted.Deleted };
-        this.publicationService.editFacsimileForPublication(payload).subscribe({
+        this.publicationService.editFacsimileForPublication(payload).pipe(take(1)).subscribe({
           next: () => {
             this.facsimilesLoader$.next(0);
             this.snackbar.open('Facsimile deleted', 'Close', { panelClass: ['snackbar-success'] });
@@ -383,7 +367,7 @@ export class PublicationsComponent implements OnInit {
     dialogRef.afterClosed().subscribe(result => {
       if (result?.value) {
         const payload = { deleted: Deleted.Deleted };
-        this.publicationService.editManuscript(manuscript.id, payload).subscribe({
+        this.publicationService.editManuscript(manuscript.id, payload).pipe(take(1)).subscribe({
           next: () => {
             this.manuscriptsLoader$.next(0);
             this.snackbar.open('Manuscript deleted', 'Close', { panelClass: ['snackbar-success'] });
@@ -405,7 +389,7 @@ export class PublicationsComponent implements OnInit {
     dialogRef.afterClosed().subscribe(result => {
       if (result?.value) {
         const payload = { deleted: Deleted.Deleted };
-        this.publicationService.editVersion(version.id, payload).subscribe({
+        this.publicationService.editVersion(version.id, payload).pipe(take(1)).subscribe({
           next: () => {
             this.versionsLoader$.next(0);
             this.snackbar.open('Variant deleted', 'Close', { panelClass: ['snackbar-success'] });
@@ -427,14 +411,14 @@ export class PublicationsComponent implements OnInit {
     dialogRef.afterClosed().subscribe(result => {
       if (result?.value) {
         const payload = { deleted: Deleted.Deleted };
-        this.publicationService.editComment(publicationId, payload).subscribe({
+        this.publicationService.editComment(publicationId, payload).pipe(take(1)).subscribe({
           next: () => {
             this.commentLoader$.next(0);
             this.snackbar.open('Comment deleted', 'Close', { panelClass: ['snackbar-success'] });
           }
         });
 
-        this.publicationService.editPublication(publicationId, { publication_comment_id: null }).subscribe({
+        this.publicationService.editPublication(publicationId, { publication_comment_id: null }).pipe(take(1)).subscribe({
           next: () => {
             this.publicationsLoader$.next(0);
           }
@@ -457,7 +441,7 @@ export class PublicationsComponent implements OnInit {
     dialogRef.afterClosed().subscribe(result => {
       if (result?.value) {
         const payload = { deleted: Deleted.Deleted, cascade_deleted: result.cascadeBoolean };
-        this.publicationService.editPublication(publication.id, payload).subscribe({
+        this.publicationService.editPublication(publication.id, payload).pipe(take(1)).subscribe({
           next: () => {
             this.publicationsLoader$.next(0);
             this.snackbar.open('Publication deleted', 'Close', { panelClass: ['snackbar-success'] });

--- a/src/app/components/translations/translations.component.ts
+++ b/src/app/components/translations/translations.component.ts
@@ -1,14 +1,15 @@
+import { CommonModule } from '@angular/common';
 import { AfterViewInit, Component, EventEmitter, input, Output, signal } from '@angular/core';
-import { BehaviorSubject, filter, Observable, switchMap, tap } from 'rxjs';
 import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
+import { MatButtonModule } from '@angular/material/button';
 import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatIconModule } from '@angular/material/icon';
 import { MatInputModule } from '@angular/material/input';
 import { MatSelectModule } from '@angular/material/select';
-import { CommonModule } from '@angular/common';
-import { MatButtonModule } from '@angular/material/button';
-import { MatIconModule } from '@angular/material/icon';
+import { BehaviorSubject, filter, Observable, switchMap, take, tap } from 'rxjs';
+
+import { languageOptions, nameForLanguage, Translation, TranslationRequestPost, TranslationResponse } from '../../models/translation';
 import { TranslationService } from '../../services/translation.service';
-import { languageOptions, nameForLanguage, Translation, TranslationRequestPost } from '../../models/translation';
 
 @Component({
   selector: 'field-translations',
@@ -82,14 +83,15 @@ export class TranslationsComponent implements AfterViewInit {
 
   onSubmitTranslation(event: Event) {
     event.preventDefault();
-    const data = this.form.getRawValue()
-    let req;
+    const data = this.form.getRawValue();
+
+    let request$: Observable<TranslationResponse>;
     if (this.mode() === 'edit') {
-      req = this.translationService.editTranslation(this.translationId as number, data)
+      request$ = this.translationService.editTranslation(this.translationId as number, data);
     } else {
-      req = this.translationService.addTranslation(data)
+      request$ = this.translationService.addTranslation(data);
     }
-    req.subscribe({
+    request$.pipe(take(1)).subscribe({
       next: res => {
         if (this.translationId == null) {
           this.translationId = res.data.translation_id;

--- a/src/app/interceptors/auth.interceptor.ts
+++ b/src/app/interceptors/auth.interceptor.ts
@@ -31,7 +31,7 @@ export const authInterceptor: HttpInterceptorFn = (req, next) => {
           catchError((refreshError) => {
             if (refreshError.status === 401) {
               authService.logout();
-              router.navigate(['/']);
+              router.navigate(['/login'], { replaceUrl: true });
             }
             return throwError(() => refreshError);
           })

--- a/src/app/pages/facsimile-collection/facsimile-collection.component.ts
+++ b/src/app/pages/facsimile-collection/facsimile-collection.component.ts
@@ -4,7 +4,7 @@ import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute, RouterLink } from '@angular/router';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
-import { Observable } from 'rxjs';
+import { Observable, take } from 'rxjs';
 
 import { FileUploadComponent } from '../../components/file-upload/file-upload.component';
 import { FacsimileCollection, VerifyFacsimileFileResponse } from '../../models/facsimile';
@@ -36,7 +36,7 @@ export class FacsimileCollectionComponent implements OnInit {
   }
 
   verifyFacsimileFiles() {
-    this.fascimileService.verifyFacsimileFile(this.collectionId, 'all').subscribe({
+    this.fascimileService.verifyFacsimileFile(this.collectionId, 'all').pipe(take(1)).subscribe({
       next: response => {
         this.missingFileNumbers = response.data?.missing_file_numbers || [];
       },

--- a/src/app/pages/facsimiles/facsimiles.component.ts
+++ b/src/app/pages/facsimiles/facsimiles.component.ts
@@ -1,25 +1,26 @@
-import { Component, OnInit } from '@angular/core';
-import { BehaviorSubject, combineLatest, map, Observable, of, switchMap } from 'rxjs';
 import { CommonModule } from '@angular/common';
-import { FacsimileCollection } from '../../models/facsimile';
-import { LoadingSpinnerComponent } from '../../components/loading-spinner/loading-spinner.component';
-import { MatTableModule } from '@angular/material/table';
-import { Column, Deleted } from '../../models/common';
-import { MatIconModule } from '@angular/material/icon';
+import { Component, OnInit } from '@angular/core';
+import { MatBadgeModule } from '@angular/material/badge';
 import { MatButtonModule } from '@angular/material/button';
 import { MatDialog } from '@angular/material/dialog';
+import { MatIconModule } from '@angular/material/icon';
 import { ScrollingModule } from '@angular/cdk/scrolling';
-import { TableFiltersComponent } from '../../components/table-filters/table-filters.component';
-import { QueryParamsService } from '../../services/query-params.service';
-import { MatBadgeModule } from '@angular/material/badge';
-import { TableSortingComponent } from '../../components/table-sorting/table-sorting.component';
-import { EditDialogComponent, EditDialogData } from '../../components/edit-dialog/edit-dialog.component';
 import { MatSnackBar } from '@angular/material/snack-bar';
-import { CustomTableComponent } from "../../components/custom-table/custom-table.component";
-import { LoadingService } from '../../services/loading.service';
+import { MatTableModule } from '@angular/material/table';
 import { Router } from '@angular/router';
-import { FacsimileService } from '../../services/facsimile.service';
+import { BehaviorSubject, combineLatest, map, Observable, of, switchMap, take } from 'rxjs';
+
 import { ConfirmDialogComponent } from '../../components/confirm-dialog/confirm-dialog.component';
+import { CustomTableComponent } from "../../components/custom-table/custom-table.component";
+import { EditDialogComponent, EditDialogData } from '../../components/edit-dialog/edit-dialog.component';
+import { LoadingSpinnerComponent } from '../../components/loading-spinner/loading-spinner.component';
+import { TableSortingComponent } from '../../components/table-sorting/table-sorting.component';
+import { TableFiltersComponent } from '../../components/table-filters/table-filters.component';
+import { FacsimileService } from '../../services/facsimile.service';
+import { LoadingService } from '../../services/loading.service';
+import { QueryParamsService } from '../../services/query-params.service';
+import { Column, Deleted } from '../../models/common';
+import { FacsimileCollection, FacsimileCollectionResponse } from '../../models/facsimile';
 
 @Component({
   selector: 'app-facsimiles',
@@ -92,16 +93,15 @@ export class FacsimilesComponent implements OnInit {
 
     dialogRef.afterClosed().subscribe(result => {
       if (result) {
-
         const payload = result.form.getRawValue();
 
-        let req;
+        let request$: Observable<FacsimileCollectionResponse>;
         if (collection?.id) {
-          req = this.facsimileService.editFacsimileCollection(collection.id, payload)
+          request$ = this.facsimileService.editFacsimileCollection(collection.id, payload);
         } else {
-          req = this.facsimileService.addFacsimileCollection(payload);
+          request$ = this.facsimileService.addFacsimileCollection(payload);
         }
-        req.subscribe({
+        request$.pipe(take(1)).subscribe({
           next: () => {
             this.loader$.next(0);
             this.snackbar.open('Facsimile collection saved', 'Close', { panelClass: ['snackbar-success'] });
@@ -141,7 +141,7 @@ export class FacsimilesComponent implements OnInit {
     dialogRef.afterClosed().subscribe(result => {
       if (result?.value) {
         const payload = { ...collection, deleted: Deleted.Deleted };
-        this.facsimileService.editFacsimileCollection(collection.id, payload).subscribe({
+        this.facsimileService.editFacsimileCollection(collection.id, payload).pipe(take(1)).subscribe({
           next: () => {
             this.loader$.next(0);
             this.snackbar.open('Facsimile collection deleted', 'Close', { panelClass: ['snackbar-success'] });

--- a/src/app/pages/new-publication-facsimile/new-publication-facsimile.component.ts
+++ b/src/app/pages/new-publication-facsimile/new-publication-facsimile.component.ts
@@ -1,26 +1,27 @@
-import { FacsimileService } from './../../services/facsimile.service';
-import { Component, OnInit } from '@angular/core';
-import { Observable } from 'rxjs';
-import { FacsimileCollection } from '../../models/facsimile';
 import { CommonModule } from '@angular/common';
-import { MatTableModule } from '@angular/material/table';
-import { CustomTableComponent } from '../../components/custom-table/custom-table.component';
-import { Column } from '../../models/common';
-import { MatIconModule } from '@angular/material/icon';
-import { QueryParamsService } from '../../services/query-params.service';
-import { MatBadgeModule } from '@angular/material/badge';
-import { TableFiltersComponent } from '../../components/table-filters/table-filters.component';
-import { MatDialog } from '@angular/material/dialog';
-import { MatButtonModule } from '@angular/material/button';
-import { Publication } from '../../models/publication';
-import { ActivatedRoute, Router, RouterLink } from '@angular/router';
+import { Component, OnInit } from '@angular/core';
 import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
+import { MatBadgeModule } from '@angular/material/badge';
+import { MatButtonModule } from '@angular/material/button';
+import { MatDialog } from '@angular/material/dialog';
 import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatIconModule } from '@angular/material/icon';
 import { MatInputModule } from '@angular/material/input';
 import { MatSnackBar } from '@angular/material/snack-bar';
-import { PublicationService } from '../../services/publication.service';
-import { LoadingService } from '../../services/loading.service';
+import { MatTableModule } from '@angular/material/table';
+import { ActivatedRoute, Router, RouterLink } from '@angular/router';
+import { Observable, take } from 'rxjs';
+
+import { CustomTableComponent } from '../../components/custom-table/custom-table.component';
 import { LoadingSpinnerComponent } from '../../components/loading-spinner/loading-spinner.component';
+import { TableFiltersComponent } from '../../components/table-filters/table-filters.component';
+import { Column } from '../../models/common';
+import { FacsimileCollection } from '../../models/facsimile';
+import { Publication } from '../../models/publication';
+import { FacsimileService } from './../../services/facsimile.service';
+import { LoadingService } from '../../services/loading.service';
+import { PublicationService } from '../../services/publication.service';
+import { QueryParamsService } from '../../services/query-params.service';
 
 @Component({
   selector: 'app-new-publication-facsimile',
@@ -55,9 +56,10 @@ export class NewPublicationFacsimileComponent implements OnInit {
     private route: ActivatedRoute,
     private router: Router,
     private snackbar: MatSnackBar,
-    private loadingService: LoadingService) {
-      this.loading$ = this.loadingService.loading$;
-      this.filterParams$ = this.queryParamsService.filterParams$
+    private loadingService: LoadingService
+  ) {
+    this.loading$ = this.loadingService.loading$;
+    this.filterParams$ = this.queryParamsService.filterParams$
   }
 
   get publicationsPath() {
@@ -102,14 +104,12 @@ export class NewPublicationFacsimileComponent implements OnInit {
     if (!payload.priority) {
       delete payload.priority;
     }
-    this.publicationService.linkFacsimileToPublication(payload.facsimile_collection_id, payload).subscribe({
+    this.publicationService.linkFacsimileToPublication(payload.facsimile_collection_id, payload).pipe(take(1)).subscribe({
       next: () => {
         this.snackbar.open('Facsimile linked to publication', 'Close', { panelClass: 'snackbar-success' });
         this.router.navigate(this.publicationsPath);
       }
     });
   }
-
-
 
 }

--- a/src/app/pages/persons/persons.component.ts
+++ b/src/app/pages/persons/persons.component.ts
@@ -1,24 +1,25 @@
-import { Component, OnInit } from '@angular/core';
-import { BehaviorSubject, combineLatest, map, Observable, of, switchMap } from 'rxjs';
-import { CommonModule, DatePipe } from '@angular/common';
-import { Person } from '../../models/person';
-import { MatTableModule } from '@angular/material/table';
-import { Column, Deleted } from '../../models/common';
-import { MatIconModule } from '@angular/material/icon';
-import { MatButtonModule } from '@angular/material/button';
-import { MatDialog } from '@angular/material/dialog';
-import { TableFiltersComponent } from '../../components/table-filters/table-filters.component';
-import { QueryParamsService } from '../../services/query-params.service';
 import { ScrollingModule } from '@angular/cdk/scrolling';
-import { MatChipsModule } from '@angular/material/chips';
+import { CommonModule, DatePipe } from '@angular/common';
+import { Component, OnInit } from '@angular/core';
 import { MatBadgeModule } from '@angular/material/badge';
-import { LoadingSpinnerComponent } from '../../components/loading-spinner/loading-spinner.component';
-import { LoadingService } from '../../services/loading.service';
-import { EditDialogComponent, EditDialogData } from '../../components/edit-dialog/edit-dialog.component';
+import { MatButtonModule } from '@angular/material/button';
+import { MatChipsModule } from '@angular/material/chips';
+import { MatDialog } from '@angular/material/dialog';
+import { MatIconModule } from '@angular/material/icon';
 import { MatSnackBar } from '@angular/material/snack-bar';
-import { CustomTableComponent } from "../../components/custom-table/custom-table.component";
-import { SubjectService } from '../../services/subject.service';
+import { MatTableModule } from '@angular/material/table';
+import { BehaviorSubject, combineLatest, map, Observable, of, switchMap, take } from 'rxjs';
+
 import { ConfirmDialogComponent } from '../../components/confirm-dialog/confirm-dialog.component';
+import { CustomTableComponent } from "../../components/custom-table/custom-table.component";
+import { EditDialogComponent, EditDialogData } from '../../components/edit-dialog/edit-dialog.component';
+import { LoadingSpinnerComponent } from '../../components/loading-spinner/loading-spinner.component';
+import { TableFiltersComponent } from '../../components/table-filters/table-filters.component';
+import { Column, Deleted } from '../../models/common';
+import { Person } from '../../models/person';
+import { LoadingService } from '../../services/loading.service';
+import { QueryParamsService } from '../../services/query-params.service';
+import { SubjectService } from '../../services/subject.service';
 
 @Component({
   selector: 'app-persons',
@@ -99,13 +100,13 @@ export class PersonsComponent implements OnInit {
 
     dialogRef.afterClosed().subscribe(result => {
       if (result) {
-        let req;
+        let request$: Observable<Person>;
         if (person?.id) {
-          req = this.subjectService.editSubject(person.id, result.form.value);
+          request$ = this.subjectService.editSubject(person.id, result.form.value);
         } else {
-          req = this.subjectService.addSubject(result.form.value);
+          request$ = this.subjectService.addSubject(result.form.value);
         }
-        req.subscribe({
+        request$.pipe(take(1)).subscribe({
           next: () => {
             this.loader$.next(0);
             this.snackaBar.open('Person saved', 'Close', { panelClass: ['snackbar-success'] });
@@ -127,7 +128,7 @@ export class PersonsComponent implements OnInit {
     dialogRef.afterClosed().subscribe(result => {
       if (result?.value === true) {
         const payload = { ...person, deleted: Deleted.Deleted };
-        this.subjectService.editSubject(person.id, payload).subscribe({
+        this.subjectService.editSubject(person.id, payload).pipe(take(1)).subscribe({
           next: () => {
             this.loader$.next(0);
             this.snackaBar.open('Person deleted', 'Close', { panelClass: ['snackbar-success'] });
@@ -135,7 +136,6 @@ export class PersonsComponent implements OnInit {
         });
       }
     });
-
   }
 
   filterPersons() {
@@ -144,6 +144,5 @@ export class PersonsComponent implements OnInit {
       data: columns
     });
   }
-
 
 }

--- a/src/app/pages/projects/projects.component.ts
+++ b/src/app/pages/projects/projects.component.ts
@@ -1,22 +1,23 @@
-import { QueryParamsService } from './../../services/query-params.service';
-import { Component, OnInit } from '@angular/core';
-import { BehaviorSubject, Observable, of, switchMap } from 'rxjs';
-import { ProjectService } from '../../services/project.service';
 import { CommonModule, DatePipe } from '@angular/common';
-import { EditProjectData, Project } from '../../models/project';
-import { MatTableModule } from '@angular/material/table';
-import { MatIconModule } from '@angular/material/icon';
-import { MatDialog } from '@angular/material/dialog';
+import { Component, OnInit } from '@angular/core';
 import { MatButtonModule } from '@angular/material/button';
+import { MatBadgeModule } from '@angular/material/badge';
+import { MatDialog } from '@angular/material/dialog';
+import { MatIconModule } from '@angular/material/icon';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { MatTableModule } from '@angular/material/table';
+import { BehaviorSubject, Observable, of, switchMap, take } from 'rxjs';
+
+import { CustomTableComponent } from "../../components/custom-table/custom-table.component";
+import { ConfirmDialogComponent } from '../../components/confirm-dialog/confirm-dialog.component';
+import { EditDialogComponent, EditDialogData } from '../../components/edit-dialog/edit-dialog.component';
+import { LoadingSpinnerComponent } from '../../components/loading-spinner/loading-spinner.component';
 import { TableFiltersComponent } from '../../components/table-filters/table-filters.component';
 import { Column, Deleted } from '../../models/common';
-import { LoadingSpinnerComponent } from '../../components/loading-spinner/loading-spinner.component';
-import { EditDialogComponent, EditDialogData } from '../../components/edit-dialog/edit-dialog.component';
-import { MatSnackBar } from '@angular/material/snack-bar';
-import { CustomTableComponent } from "../../components/custom-table/custom-table.component";
+import { EditProjectData, Project, ProjectResponse } from '../../models/project';
 import { LoadingService } from '../../services/loading.service';
-import { ConfirmDialogComponent } from '../../components/confirm-dialog/confirm-dialog.component';
-import { MatBadgeModule } from '@angular/material/badge';
+import { ProjectService } from '../../services/project.service';
+import { QueryParamsService } from './../../services/query-params.service';
 
 @Component({
   selector: 'app-projects',
@@ -80,16 +81,16 @@ export class ProjectsComponent implements OnInit {
     dialogRef.afterClosed().subscribe(result => {
       if (result) {
         const data = result.form.value as EditProjectData;
-        let req;
+        let request$: Observable<ProjectResponse>;
         if (project?.id) {
-          req = this.projectService.editProject(project.id, data);
+          request$ = this.projectService.editProject(project.id, data);
         } else {
-          req = this.projectService.addProject(data);
+          request$ = this.projectService.addProject(data);
         }
-        req.subscribe({
+        request$.pipe(take(1)).subscribe({
           next: () => {
             this.loader$.next(0);
-            this.snackBar.open('Project saved successfully', 'Close', { panelClass: ['snackbar-success'] });
+            this.snackBar.open('Project saved', 'Close', { panelClass: ['snackbar-success'] });
           }
         });
       }
@@ -115,10 +116,10 @@ export class ProjectsComponent implements OnInit {
     dialogRef.afterClosed().subscribe(result => {
       if (result?.value) {
         const payload = { ...project, deleted: Deleted.Deleted };
-        this.projectService.editProject(project.id, payload).subscribe({
+        this.projectService.editProject(project.id, payload).pipe(take(1)).subscribe({
           next: () => {
             this.loader$.next(0);
-            this.snackBar.open('Project deleted successfully', 'Close', { panelClass: ['snackbar-success'] });
+            this.snackBar.open('Project deleted', 'Close', { panelClass: ['snackbar-success'] });
           }
         });
       }

--- a/src/app/pages/publication-bundle/publication-bundle.component.ts
+++ b/src/app/pages/publication-bundle/publication-bundle.component.ts
@@ -10,7 +10,7 @@ import { MatInputModule } from '@angular/material/input';
 import { MatSelectModule } from '@angular/material/select';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { MatTooltipModule } from '@angular/material/tooltip';
-import { combineLatest, finalize, from, map, mergeMap, Observable, of, switchMap } from 'rxjs';
+import { combineLatest, finalize, from, map, mergeMap, Observable, of, switchMap, take } from 'rxjs';
 
 import { FileTreeComponent } from '../../components/file-tree/file-tree.component';
 import { LoadingSpinnerComponent } from '../../components/loading-spinner/loading-spinner.component';
@@ -66,11 +66,11 @@ export class PublicationBundleComponent implements OnInit {
   }
 
   constructor(
-      private publicationService: PublicationService,
-      private route: ActivatedRoute,
-      private snackbar: MatSnackBar,
-      private loadingService: LoadingService,
-      private router: Router
+    private publicationService: PublicationService,
+    private route: ActivatedRoute,
+    private snackbar: MatSnackBar,
+    private loadingService: LoadingService,
+    private router: Router
   ) {
     this.loading$ = this.loadingService.loading$;
     this.selectedProject$ = this.publicationService.selectedProject$;
@@ -136,6 +136,7 @@ export class PublicationBundleComponent implements OnInit {
     return new Observable<void>(observer => {
       const originalFilename = row.get('original_filename')!.value;
       this.publicationService.getMetadataFromXML(originalFilename)
+        .pipe(take(1))
         .subscribe({
           next: (metadata: XmlMetadata) => {
             for (const key in metadata) {
@@ -164,11 +165,11 @@ export class PublicationBundleComponent implements OnInit {
 
   onSubmit(collectionId: string) {
     const concurrentRequests = 5;
-    const throrrledRequests$ = from(this.files.controls).pipe(
+    const throttledRequests$ = from(this.files.controls).pipe(
       mergeMap((row) => this.addPublication(row, parseInt(collectionId)), concurrentRequests)
     );
 
-    throrrledRequests$.subscribe({
+    throttledRequests$.subscribe({
       complete: () => {
         this.snackbar.open('All publications added', 'Close', { panelClass: 'snackbar-success' });
         this.clearForm();
@@ -184,6 +185,7 @@ export class PublicationBundleComponent implements OnInit {
       const data = row.getRawValue() as PublicationAddRequest;
       data.published = this.bundleForm.value.published as Published;
       this.publicationService.addPublication(collectionId, data)
+        .pipe(take(1))
         .subscribe({
           next: () => {
             observer.next();
@@ -197,6 +199,5 @@ export class PublicationBundleComponent implements OnInit {
         });
     });
   }
-
 
 }

--- a/src/app/pages/publication-collections/publication-collections.component.ts
+++ b/src/app/pages/publication-collections/publication-collections.component.ts
@@ -1,25 +1,26 @@
-import { LoadingService } from './../../services/loading.service';
 import { CommonModule, DatePipe } from '@angular/common';
 import { Component, OnInit } from '@angular/core';
-import { BehaviorSubject, combineLatest, filter, map, Observable, of, switchMap } from 'rxjs';
-import { PublicationCollection } from '../../models/publication';
-import { MatTableModule } from '@angular/material/table';
-import { Column, Deleted } from '../../models/common';
-import { MatIconModule } from '@angular/material/icon';
+import { MatBadgeModule } from '@angular/material/badge';
 import { MatButtonModule } from '@angular/material/button';
-import { ActivatedRoute, RouterLink } from '@angular/router';
-import { LoadingSpinnerComponent } from '../../components/loading-spinner/loading-spinner.component';
 import { MatDialog } from '@angular/material/dialog';
+import { MatIconModule } from '@angular/material/icon';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { MatTableModule } from '@angular/material/table';
+import { ActivatedRoute, RouterLink } from '@angular/router';
+import { BehaviorSubject, combineLatest, filter, map, Observable, of, switchMap, take } from 'rxjs';
+
+import { ConfirmDialogComponent } from '../../components/confirm-dialog/confirm-dialog.component';
+import { CustomTableComponent } from "../../components/custom-table/custom-table.component";
+import { EditDialogComponent, EditDialogData } from '../../components/edit-dialog/edit-dialog.component';
+import { LoadingSpinnerComponent } from '../../components/loading-spinner/loading-spinner.component';
 import { PublicationsComponent } from "../../components/publications/publications.component";
 import { TableFiltersComponent } from '../../components/table-filters/table-filters.component';
-import { QueryParamsService } from '../../services/query-params.service';
 import { TableSortingComponent } from '../../components/table-sorting/table-sorting.component';
-import { MatBadgeModule } from '@angular/material/badge';
-import { EditDialogComponent, EditDialogData } from '../../components/edit-dialog/edit-dialog.component';
-import { MatSnackBar } from '@angular/material/snack-bar';
-import { CustomTableComponent } from "../../components/custom-table/custom-table.component";
+import { Column, Deleted } from '../../models/common';
+import { PublicationCollection, PublicationCollectionResponse } from '../../models/publication';
+import { LoadingService } from './../../services/loading.service';
 import { PublicationService } from '../../services/publication.service';
-import { ConfirmDialogComponent } from '../../components/confirm-dialog/confirm-dialog.component';
+import { QueryParamsService } from '../../services/query-params.service';
 
 @Component({
   selector: 'publication-collections',
@@ -111,13 +112,13 @@ export class PublicationCollectionsComponent implements OnInit {
 
     dialogRef.afterClosed().subscribe(result => {
       if (result) {
-        let req;
+        let request$: Observable<PublicationCollectionResponse>;
         if (publicationCollection?.id) {
-          req = this.publicationService.editPublicationCollection(publicationCollection.id, result.form.value);
+          request$ = this.publicationService.editPublicationCollection(publicationCollection.id, result.form.value);
         } else {
-          req = this.publicationService.addPublicationCollection(result.form.value);
+          request$ = this.publicationService.addPublicationCollection(result.form.value);
         }
-        req.subscribe({
+        request$.pipe(take(1)).subscribe({
           next: () => {
             this.loader$.next(0);
             this.snackbar.open('Publication collection saved', 'Close', { panelClass: ['snackbar-success'] });
@@ -141,7 +142,7 @@ export class PublicationCollectionsComponent implements OnInit {
     dialogRef.afterClosed().subscribe(result => {
       if (result?.value) {
         const payload = { deleted: Deleted.Deleted, cascade_deleted: result.cascadeBoolean };
-        this.publicationService.editPublicationCollection(collection.id, payload).subscribe({
+        this.publicationService.editPublicationCollection(collection.id, payload).pipe(take(1)).subscribe({
           next: () => {
             this.loader$.next(0);
             this.snackbar.open('Publication collection deleted', 'Close', { panelClass: ['snackbar-success'] });

--- a/src/app/services/auth.service.ts
+++ b/src/app/services/auth.service.ts
@@ -1,9 +1,10 @@
-import { BehaviorSubject, catchError, filter, map, Observable, take, throwError } from 'rxjs';
-import { ApiService } from './api.service';
 import { inject, Injectable } from '@angular/core';
-import { LoginRequest, LoginResponse, RefreshTokenResponse } from '../models/login';
-import { Router } from '@angular/router';
 import { MatSnackBar } from '@angular/material/snack-bar';
+import { Router } from '@angular/router';
+import { BehaviorSubject, catchError, filter, map, Observable, take, throwError } from 'rxjs';
+
+import { LoginRequest, LoginResponse, RefreshTokenResponse } from '../models/login';
+import { ApiService } from './api.service';
 import { ProjectService } from './project.service';
 
 @Injectable({
@@ -11,7 +12,11 @@ import { ProjectService } from './project.service';
 })
 export class AuthService {
 
-  constructor(private apiService: ApiService, private router: Router, private projectService: ProjectService) {
+  constructor(
+    private apiService: ApiService,
+    private router: Router,
+    private projectService: ProjectService
+  ) {
     if (this.getAccessToken()) {
       this.isAuthenticated$.next(true);
     } else {

--- a/src/app/services/facsimile.service.ts
+++ b/src/app/services/facsimile.service.ts
@@ -1,19 +1,25 @@
+import { HttpContext } from '@angular/common/http';
 import { Injectable } from '@angular/core';
+import { BehaviorSubject, filter, map, switchMap } from 'rxjs';
+
+import { SkipLoading } from '../interceptors/loading.interceptor';
+import {
+  FacsimileCollection, FacsimileCollectionCreateRequest, FacsimileCollectionEditRequest,
+  FacsimileCollectionResponse, FacsimileCollectionsResponse, VerifyFacsimileFileResponse
+} from '../models/facsimile';
 import { ApiService } from './api.service';
 import { ProjectService } from './project.service';
-import { FacsimileCollection, FacsimileCollectionCreateRequest, FacsimileCollectionEditRequest, FacsimileCollectionResponse, FacsimileCollectionsResponse, VerifyFacsimileFileResponse } from '../models/facsimile';
-import { filter, map, switchMap } from 'rxjs';
-import { HttpContext } from '@angular/common/http';
-import { SkipLoading } from '../interceptors/loading.interceptor';
 
 @Injectable({
   providedIn: 'root'
 })
 export class FacsimileService {
+  selectedProject$: BehaviorSubject<string | null>;
 
-  selectedProject$;
-
-  constructor(private apiService: ApiService, private projectService: ProjectService) {
+  constructor(
+    private apiService: ApiService,
+    private projectService: ProjectService
+  ) {
     this.selectedProject$ = this.projectService.selectedProject$;
   }
 

--- a/src/app/services/project.service.ts
+++ b/src/app/services/project.service.ts
@@ -1,15 +1,18 @@
-import { Injectable } from '@angular/core';
-import { ApiService } from './api.service';
-import { BehaviorSubject, filter, map, Observable, switchMap, take } from 'rxjs';
-import { AddProjectData, EditProjectData, FileTree, FileTreeResponse, Project, ProjectResponse, ProjectsResponse, RepoDetails, RepoDetailsResponse, SyncFilesResponse } from '../models/project';
 import { HttpContext } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { BehaviorSubject, filter, map, Observable, switchMap, take } from 'rxjs';
+
 import { SkipLoading } from '../interceptors/loading.interceptor';
+import {
+  AddProjectData, EditProjectData, FileTree, FileTreeResponse, Project, ProjectResponse,
+  ProjectsResponse, RepoDetails, RepoDetailsResponse, SyncFilesResponse
+} from '../models/project';
+import { ApiService } from './api.service';
 
 @Injectable({
   providedIn: 'root'
 })
 export class ProjectService {
-
   selectedProject$: BehaviorSubject<string | null> = new BehaviorSubject<string | null>(null);
   fileTree$: BehaviorSubject<FileTree | null> = new BehaviorSubject<FileTree | null>(null);
 

--- a/src/app/services/publication.service.ts
+++ b/src/app/services/publication.service.ts
@@ -1,24 +1,27 @@
-import { ManuscriptResponse, PublicationCommentsResponse } from './../models/publication';
-import { ProjectService } from './project.service';
 import { Injectable } from '@angular/core';
-import { filter, map, switchMap } from 'rxjs';
-import { ApiService } from './api.service';
+import { BehaviorSubject, filter, map, switchMap } from 'rxjs';
+
 import {
-  LinkTextToPublicationRequest, LinkTextToPublicationResponse, ManuscriptEditRequest, ManuscriptsResponse, Publication, PublicationAddRequest,
-  PublicationCollectionAddRequest, PublicationCollectionEditRequest, PublicationCollectionResponse, PublicationCollectionsResponse,
-  PublicationCommentRequest, PublicationCommentResponse, PublicationEditRequest, PublicationResponse, PublicationsResponse, VersionEditRequest,
-  VersionResponse, VersionsResponse, XmlMetadataResponse
-} from '../models/publication';
-import {
-  EditPublicationFacsimileRequest, LinkFacsimileToPublicationResponse, LinkPublicationToFacsimileRequest, PublicationFacsimileResponse
+  EditPublicationFacsimileRequest, LinkFacsimileToPublicationResponse,
+  LinkPublicationToFacsimileRequest, PublicationFacsimileResponse
 } from '../models/facsimile';
+import {
+  LinkTextToPublicationRequest, LinkTextToPublicationResponse, ManuscriptEditRequest,
+  ManuscriptResponse, ManuscriptsResponse, Publication, PublicationAddRequest,
+  PublicationCollectionAddRequest, PublicationCollectionEditRequest,
+  PublicationCollectionResponse, PublicationCollectionsResponse, PublicationCommentRequest,
+  PublicationCommentResponse, PublicationCommentsResponse, PublicationEditRequest,
+  PublicationResponse, PublicationsResponse, VersionEditRequest, VersionResponse,
+  VersionsResponse, XmlMetadataResponse
+} from '../models/publication';
+import { ApiService } from './api.service';
+import { ProjectService } from './project.service';
 
 @Injectable({
   providedIn: 'root'
 })
 export class PublicationService {
-
-  selectedProject$;
+  selectedProject$: BehaviorSubject<string | null>;
 
   constructor(private apiService: ApiService, private projectService: ProjectService) {
     this.selectedProject$ = this.projectService.selectedProject$;


### PR DESCRIPTION
Our POST methods (e.g., linkTextToPublication, editManuscript) depended on selectedProject$, which is a BehaviorSubject. Because these Observables stayed subscribed after the first emission, they were re-triggered anytime selectedProject$ emitted again—such as when logging out and then logging back in, or when manually switching projects.

This caused duplicate database writes for the same user action.

To fix this, we added `.take(1)` at the component level for every one-shot POST call derived from selectedProject$.