### PR TITLE
fix: comments, versions, manuscripts, facsimiles not loading on selected publication change

### DIFF
--- a/src/app/components/publications/publications.component.ts
+++ b/src/app/components/publications/publications.component.ts
@@ -36,7 +36,7 @@ import { LinkTextToPublicationResponse, LinkTextToPublicationRequest, Manuscript
          ManuscriptResponse, Publication, PublicationComment, PublicationCommentResponse,
          PublicationEditRequest, PublicationResponse, Version, VersionResponse,
          XmlMetadata } from '../../models/publication';
-import { cleanEmptyStrings, cleanObject } from '../../utils/utility-functions';
+import { cleanEmptyStrings, cleanObject, shallowArrayEqual } from '../../utils/utility-functions';
 
 @Component({
   selector: 'publications',
@@ -129,7 +129,7 @@ export class PublicationsComponent implements OnInit {
 
     this.comments$ = this.commentLoader$.asObservable().pipe(
       switchMap(() => combineLatest([this.selectedProject$, this.publicationCollectionId$, this.publicationId$]).pipe(
-        distinctUntilChanged(([, prevCollectionId], [, nextCollectionId]) => prevCollectionId === nextCollectionId),
+        distinctUntilChanged(shallowArrayEqual),
         switchMap(([project, collectionId, publicationId]) => {
           if (!project) { return of([]); }
           return this.publicationService.getCommentsForPublication(collectionId as string, publicationId as string, project);
@@ -139,7 +139,7 @@ export class PublicationsComponent implements OnInit {
 
     this.versions$ = this.versionsLoader$.asObservable().pipe(
       switchMap(() => combineLatest([this.selectedProject$, this.publicationCollectionId$, this.publicationId$]).pipe(
-        distinctUntilChanged(([, prevCollectionId], [, nextCollectionId]) => prevCollectionId === nextCollectionId),
+        distinctUntilChanged(shallowArrayEqual),
         switchMap(([project, , publicationId]) => {
           if (!project) { return of([]); }
           return this.publicationService.getVersionsForPublication(publicationId as string, project);
@@ -149,7 +149,7 @@ export class PublicationsComponent implements OnInit {
 
     this.manuscripts$ = this.manuscriptsLoader$.asObservable().pipe(
       switchMap(() => combineLatest([this.selectedProject$, this.publicationCollectionId$, this.publicationId$]).pipe(
-        distinctUntilChanged(([, prevCollectionId], [, nextCollectionId]) => prevCollectionId === nextCollectionId),
+        distinctUntilChanged(shallowArrayEqual),
         switchMap(([project, , publicationId]) => {
           if (!project) { return of([]); }
           return this.publicationService.getManuscriptsForPublication(publicationId as string, project);
@@ -159,7 +159,7 @@ export class PublicationsComponent implements OnInit {
 
     this.facsimiles$ = this.facsimilesLoader$.asObservable().pipe(
       switchMap(() => combineLatest([this.selectedProject$, this.publicationCollectionId$, this.publicationId$]).pipe(
-        distinctUntilChanged(([, prevCollectionId], [, nextCollectionId]) => prevCollectionId === nextCollectionId),
+        distinctUntilChanged(shallowArrayEqual),
         switchMap(([project, , publicationId]) => {
           if (!project) { return of([]); }
           return this.publicationService.getFacsimilesForPublication(publicationId as string, project);

--- a/src/app/utils/utility-functions.ts
+++ b/src/app/utils/utility-functions.ts
@@ -46,3 +46,28 @@ export function cleanEmptyStrings<T extends object>(obj: T): T {
   }
   return cleaned as T;
 }
+
+
+/**
+ * Compare two arrays of primitive values (e.g., string, number,
+ * boolean, null, undefined) for shallow equality. Returns true if
+ * both arrays have the same length and each element is strictly equal
+ * (`===`) at the same index.
+ *
+ * This is useful as a comparator for RxJS operators like
+ * `distinctUntilChanged`, when working with `combineLatest` tuples of
+ * primitive values. For example, it prevents duplicate emissions when
+ * all tuple elements are unchanged, even though the arrays are new
+ * references.
+ *
+ * @param a - First array of primitive values
+ * @param b - Second array of primitive values
+ * @returns true if arrays are the same length and all corresponding elements match strictly
+ */
+export function shallowArrayEqual<T extends readonly unknown[]>(a: T, b: T): boolean {
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) {
+    if (a[i] !== b[i]) return false;
+  }
+  return true;
+}


### PR DESCRIPTION
In `publications.component.ts` reloading of comments, versions, manuscripts and facsimiles of a selected publication does not happen when the selected publication changes, because `distinctUntilChanged` only compares if `collectionId` has changed. This PR fixes it by comparing all three of `project`, `collectionId` and `publicationId` for changes.

Steps to test this:

1. Log in to the development environment.
2. Choose the `topelius` project.
3. Go to `Text collection management`.
4. Select the collection `Ljungblommor`, id 199.
5. Select a publication by clicking on it's id.
6. Observe the comments, facsimiles, manuscripts and variants tables of the selected publication, and then select another publication by clicking on it's id.

The values in the comments, facsimiles, manuscripts and variants tables don't update when you select another publication. But with this PR, they update again.

The bug was introduced in commit [bd0e088](https://github.com/slsfi/digital-edition-cms-vincent/commit/bd0e088553afa67faf939d367715a2a8db6a4672) which refactored selectedProject-reactive dependencies.