### PR TITLE
Duplicate call logic fixed,

### DIFF
--- a/src/app/components/custom-table/custom-table.component.ts
+++ b/src/app/components/custom-table/custom-table.component.ts
@@ -8,7 +8,7 @@ import { MatCheckboxModule } from '@angular/material/checkbox';
 import { MatIconModule } from '@angular/material/icon';
 import { MatPaginator, MatPaginatorModule, PageEvent } from '@angular/material/paginator';
 import { MatTableDataSource, MatTableModule } from '@angular/material/table';
-import { BehaviorSubject, combineLatest, map, Observable, Subject, takeUntil } from 'rxjs';
+import { BehaviorSubject, combineLatest, map, Observable, Subject, takeUntil, tap, shareReplay } from 'rxjs';
 
 import { Column } from '../../models/common';
 import { CustomDatePipe } from '../../pipes/custom-date.pipe';
@@ -90,14 +90,17 @@ export class CustomTableComponent<T> implements OnInit, AfterViewInit, OnDestroy
     }
     this.filterableColumns = this.originalColumns.filter(column => column.filterable);
 
-    // Subscribe to the data stream and store the original data
-    this.data$.pipe(takeUntil(this.destroy$)).subscribe(data => {
-      this.originalData = [...data]; // Create a copy of the data for resetting
-      this.originalCount = data.length;
-    });
+    // Prepare data stream that also updates original data snapshot
+    const dataWithOriginal$ = this.data$.pipe(
+      tap(data => {
+        this.originalData = [...data];
+        this.originalCount = data.length;
+      }),
+      shareReplay({ bufferSize: 1, refCount: true })
+    );
 
-    // Subscribe to data stream and queryParams for filtering and sorting of data
-    combineLatest([this.data$, this.queryParams$]).pipe(
+    // Subscribe to combined stream for filtering and sorting of data
+    combineLatest([dataWithOriginal$, this.queryParams$]).pipe(
       takeUntil(this.destroy$),
       map(([data, queryParams]) => {
         // Filtering logic


### PR DESCRIPTION
 additionally publication service logic teaked to have caching to prevent duplicate calls from the service. Duplicates were being sent from the service as well. The component should now prevent duplicate subscriptions by default.