### PR TITLE
build(ci): harden Docker image build pipeline, update `nginx` to 1.28…

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,17 @@
+# .dockerignore
+
+dist
+server/dist
+node_modules
+server/node_modules
+.angular
+.vscode
+.idea
+.git
+.github
+coverage
+*.log
+.env
+.env.*
+!.env.example
+README*

--- a/.github/workflows/docker-build-and-push.yml
+++ b/.github/workflows/docker-build-and-push.yml
@@ -29,46 +29,41 @@ jobs:
       # Define tag of official nginx image to be used as the final image
       # for the build, this is passed as a build argument to Dockerfile
       # https://hub.docker.com/_/nginx
-      NGINX_IMAGE_TAG: 1.28.0-alpine
+      NGINX_IMAGE_TAG: 1.28.2-alpine
 
     steps:
-      # Check out repository.
-      - uses: actions/checkout@v4
+      # 1) Check out repository.
+      - uses: actions/checkout@v6
 
-      # Log in with GitHub token credentials.
+      # 2) Authenticate to GitHub Container Registry.
       - name: Log in to ghcr.io
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      # Pull latest Node image with tag defined above, otherwise an older
-      # cached image might be used.
-      - name: Pull latest Node.js image
-        run: docker pull node:${{ env.NODE_IMAGE_TAG }}
+      # 3) Create a Buildx builder. Buildx uses BuildKit under the hood.
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
 
-      # Pull latest nginx image with tag defined above, otherwise an older
-      # cached image might be used.
-      - name: Pull latest nginx image
-        run: docker pull nginx:${{ env.NGINX_IMAGE_TAG }}
-
-      # Pull metadata from GitHub events (so we can use release version
+      # 4) Pull metadata from GitHub events (so we can use release version
       # number).
       - name: Pull metadata from GitHub
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ghcr.io/${{ github.repository }}
 
-      # Build image, tagging with the release tag and "latest" on a release, 
-      # or with "main" if built against main (commit push) or built using
-      # workflow_dispatch.
-      - name: Build and push docker image
-        uses: docker/build-push-action@v5
+      # 5) Build image, tagging with the release tag and "latest" on a
+      # release, or with "main" if built against main (commit push) or
+      # built using workflow_dispatch.
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v7
         with:
           context: .
           push: true
+          pull: true
           file: Dockerfile
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+### Changed
+
+- CI: harden Docker image build pipeline, update `nginx` to 1.28.2, and update actions.
+
 
 
 ## [2.1.0] – 2026-01-08

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,6 @@
 # only necessary build artifacts and resources are
 # included in the final image.
 
-# Define Angular major version used by the app, used to install
-# corresponding Angular CLI globally.
-ARG ANGULAR_MAJOR_VERSION=20
-
 # Enable passing the tag of the Node.js image as a build argument,
 # and define a default tag in case the build argument is not passed.
 # The Node.js image is used as the build image of the app,
@@ -16,20 +12,18 @@ ARG NODE_IMAGE_TAG=22-alpine
 # and define a default tag in case the build argument is not passed.
 # The nginx image is used as the final image of the app,
 # https://hub.docker.com/_/nginx.
-ARG NGINX_IMAGE_TAG=1.28.0-alpine
+ARG NGINX_IMAGE_TAG=1.28.2-alpine
 
 # 1. Create intermediate build image from official Node.js image.
 FROM node:${NODE_IMAGE_TAG} AS build
-# Redeclare ARG-variable to make it available in this stage.
-ARG ANGULAR_MAJOR_VERSION
 # Change working directory.
 WORKDIR /digital-edition-cms-vincent
-# Copy all files to the working directory.
+# Copy dependency manifests first to maximize layer cache reuse.
+COPY package.json package-lock.json ./
+# Install app dependencies deterministically.
+RUN npm ci
+# Copy all remaining files to the working directory.
 COPY . .
-# Install the Angular CLI globally.
-RUN npm install -g @angular/cli@${ANGULAR_MAJOR_VERSION}
-# Install app dependencies.
-RUN npm install
 # Build the Angular app.
 RUN npm run build
 


### PR DESCRIPTION
….2, and update actions

- add explicit Docker Buildx setup before the image build step
- ensure fresh base images via build-push `pull: true`
- remove redundant manual `docker pull` steps from workflow
- make Docker builds deterministic by switching `npm install` to `npm ci`
- improve Docker layer caching by copying lock/manifests before source
- remove unnecessary global Angular CLI install from Docker build stage
- update `nginx` to 1.28.2
- update actions